### PR TITLE
Ad 15 Vispy Object(Box, Rectangle 등) scene 사용에 대한 자원 낭비 문제 해결

### DIFF
--- a/SADAT/gui/planview.py
+++ b/SADAT/gui/planview.py
@@ -39,7 +39,8 @@ class planView(QWidget):
     def drawEgoVehicle(self):
         box = visuals.Box(width=1, height=1, depth=1, color=(0.5, 0.5, 1, 0), edge_color='white')
         # box.transform = MatrixTransform()
-        box.transform = transforms.STTransform(translate=(0., 0., 0.), scale=(1., 1., 1.))
+        box.transform = transforms.STTransform(translate=(0., 0., 0.), scale=(0.7, 0.35, 0.2))
+        self.view.add(box)
 
 
     def draw(self):
@@ -65,7 +66,6 @@ class planView(QWidget):
 
     def __drawVisible(self, viewitem, dataview, pos, size, color):
         if dataview.viewType == DataTypeCategory.POINT_CLOUD:
-            #print('pcl - ',pos[:,:3])
             viewitem.set_data(pos=pos[:, :3], face_color=color, size=2, edge_color=color)
         elif dataview.viewType == DataTypeCategory.TRACK:
             viewitem.transform.translate = pos
@@ -105,7 +105,6 @@ class planView(QWidget):
             return visuals.Markers(edge_color=None, size=2), dataview.rawid
         elif dataview.viewType == DataTypeCategory.TRACK: #Track Visual 부분을 Box 말고 다른 view로 바꿔봐야할 것 같음...
             box = visuals.Box(width=1, height=1, depth=1, color=(0.5, 0.5, 1, 0), edge_color='white')
-            #box.transform = MatrixTransform()
             box.transform = transforms.STTransform(translate=(0., 0., 0.), scale=(1., 1., 1.))
             return box, dataview.rawid
             #return visuals.Markers(edge_color=None, size=10, symbol='square'), dataview.rawid

--- a/SADAT/gui/planview.py
+++ b/SADAT/gui/planview.py
@@ -29,7 +29,17 @@ class planView(QWidget):
         hbox.addWidget(self.canvas.native)
         hbox.setContentsMargins(0,0,0,0)
         self.setLayout(hbox)
+
+        #add ego vehicle
+        self.drawEgoVehicle()
+
+        #draw objects
         self.draw()
+
+    def drawEgoVehicle(self):
+        box = visuals.Box(width=1, height=1, depth=1, color=(0.5, 0.5, 1, 0), edge_color='white')
+        # box.transform = MatrixTransform()
+        box.transform = transforms.STTransform(translate=(0., 0., 0.), scale=(1., 1., 1.))
 
 
     def draw(self):
@@ -58,20 +68,10 @@ class planView(QWidget):
             #print('pcl - ',pos[:,:3])
             viewitem.set_data(pos=pos[:, :3], face_color=color, size=2, edge_color=color)
         elif dataview.viewType == DataTypeCategory.TRACK:
-            # arr = np.empty((0,3), float)
-            # arr = np.append(arr, np.array([pos[:3]]), axis=0)
-            # viewitem.set_data(pos=arr, size=10, symbol='square')
-
-            # viewitem.transform.reset()
-            # viewitem.transform.scale(size)
-            # viewitem.transform.translate(pos)
-            tr = np.array(viewitem.transform.translate)
-            sc = np.array(viewitem.transform.scale)
-            tr = pos
-            sc = size
-            viewitem.transform.translate = tr
-            viewitem.transform.scale = sc
-            pass
+            viewitem.transform.translate = pos
+            viewitem.transform.scale = size
+            if viewitem.border.color.alpha == 0:
+                viewitem.border.color = (1, 1, 1, 1)
         elif dataview.viewType == DataTypeCategory.LINE:
             pass
         elif dataview.viewType == DataTypeCategory.LANE:
@@ -81,8 +81,8 @@ class planView(QWidget):
         if dataview.viewType == DataTypeCategory.POINT_CLOUD:
             viewitem.set_data(pos=np.array([[0,0,0]]),size=0)
         elif dataview.viewType == DataTypeCategory.TRACK:
-            viewitem.transform.reset()
-            viewitem.transform.scale((0.1,0.1,0.1))
+            viewitem.border.color = (1, 1, 1, 0)
+
         elif dataview.viewType == DataTypeCategory.LINE:
             pass
         elif dataview.viewType == DataTypeCategory.LANE:

--- a/SADAT/gui/planview.py
+++ b/SADAT/gui/planview.py
@@ -4,6 +4,7 @@ from PyQt5.QtWidgets import QWidget, QHBoxLayout
 from PyQt5 import QtGui
 import numpy as np
 from vispy.visuals.transforms import MatrixTransform
+from vispy.visuals import transforms
 
 from dadatype.dtype_cate import DataTypeCategory
 
@@ -54,11 +55,23 @@ class planView(QWidget):
 
     def __drawVisible(self, viewitem, dataview, pos, size, color):
         if dataview.viewType == DataTypeCategory.POINT_CLOUD:
+            #print('pcl - ',pos[:,:3])
             viewitem.set_data(pos=pos[:, :3], face_color=color, size=2, edge_color=color)
         elif dataview.viewType == DataTypeCategory.TRACK:
-            viewitem.transform.reset()
-            viewitem.transform.scale(size)
-            viewitem.transform.translate(pos)
+            # arr = np.empty((0,3), float)
+            # arr = np.append(arr, np.array([pos[:3]]), axis=0)
+            # viewitem.set_data(pos=arr, size=10, symbol='square')
+
+            # viewitem.transform.reset()
+            # viewitem.transform.scale(size)
+            # viewitem.transform.translate(pos)
+            tr = np.array(viewitem.transform.translate)
+            sc = np.array(viewitem.transform.scale)
+            tr = pos
+            sc = size
+            viewitem.transform.translate = tr
+            viewitem.transform.scale = sc
+            pass
         elif dataview.viewType == DataTypeCategory.LINE:
             pass
         elif dataview.viewType == DataTypeCategory.LANE:
@@ -92,7 +105,9 @@ class planView(QWidget):
             return visuals.Markers(edge_color=None, size=2), dataview.rawid
         elif dataview.viewType == DataTypeCategory.TRACK: #Track Visual 부분을 Box 말고 다른 view로 바꿔봐야할 것 같음...
             box = visuals.Box(width=1, height=1, depth=1, color=(0.5, 0.5, 1, 0), edge_color='white')
-            box.transform = MatrixTransform()
+            #box.transform = MatrixTransform()
+            box.transform = transforms.STTransform(translate=(0., 0., 0.), scale=(1., 1., 1.))
             return box, dataview.rawid
+            #return visuals.Markers(edge_color=None, size=10, symbol='square'), dataview.rawid
         else: #need to add line
             return None

--- a/SADAT/sensor/SenAdptMgr.py
+++ b/SADAT/sensor/SenAdptMgr.py
@@ -12,7 +12,8 @@ from utils.sadatlogger import slog
 class AttachedSensorName(Enum):
     #Physical
     RPLidar2DA3 = 'rplidar:/scan:/scan'
-    Tracker = 'track:/lidar_tracker_geometry:geometry_msgs/PoseArray'
+    LidarTracker = 'lidartrack:/lidar_tracker_geometry:geometry_msgs/PoseArray'
+    CamTracker = 'camtrack:/cam_tracker_geometry:geometry_msgs/PoseArray'
     USBCAM = 'usbcam:/usb_cam/image_raw/compressed:sensor_msgs/CompressedImage'
     ZEDCAM = 'zedcam:/zed2/zed_node/right/image_rect_color/compressed:sensor_msgs/CompressedImage'
     VelodyneVLC16 = 'velodyne pointcloud:/velodyne_points:pointcloud2'


### PR DESCRIPTION
### 문제
- SADAT은 planview에서 pointcloud 및 track 정보들을 출력할 때 object scene 사용
- pointcloud는 markers를 이용
> - markers는 data를 update 할 때 setdata() 함수를 사용하여 포인트의 위치만 변경
- Track, text 데이터는 object scene(Box, Rectangle 등) 이용
> - data를 업데이트할 때 transform을 모두 초기화 하고 재설정 함
> - transform 초기화 및 재설정 과정에서 과도한 자원 사용
### 해결방법
- Transform을 STTransform으로 교체
- transform 초기화가 아닌 위치와 scale만 단순 교체 -> 추후 위치만 교체하면 될듯
`box.transform = transforms.STTransform(translate=(0., 0., 0.), scale=(1., 1., 1.))`
`viewitem.transform.translate = pos`
`viewitem.transform.scale = size`